### PR TITLE
Table removal after use

### DIFF
--- a/src/main/kotlin/no/uio/bedreflyt/api/controller/SimulationController.kt
+++ b/src/main/kotlin/no/uio/bedreflyt/api/controller/SimulationController.kt
@@ -445,7 +445,13 @@ class SimulationController (
             databaseService.insertTreatment(treatmentDbUrl, diagnosis, orderInJourney, task)
         }
 
-        return simulate()
+        val sim = simulate()
+
+        databaseService.deleteDatabase(roomDbUrl)
+        databaseService.deleteDatabase(scenarioDbUrl)
+        databaseService.deleteDatabase(treatmentDbUrl)
+
+        return sim
     }
 
 

--- a/src/main/kotlin/no/uio/bedreflyt/api/service/simulation/DatabaseService.kt
+++ b/src/main/kotlin/no/uio/bedreflyt/api/service/simulation/DatabaseService.kt
@@ -98,6 +98,18 @@ class DatabaseService {
         jdbcTemplate.execute(createTreatmentTable)
     }
 
+    fun deleteDatabase(dbPath: String) {
+        val jdbcTemplate = getJdbcTemplate(dbPath)
+        jdbcTemplate.execute("DROP TABLE IF EXISTS patient")
+        jdbcTemplate.execute("DROP TABLE IF EXISTS patientStatus")
+        jdbcTemplate.execute("DROP TABLE IF EXISTS scenario")
+        jdbcTemplate.execute("DROP TABLE IF EXISTS roomCategory")
+        jdbcTemplate.execute("DROP TABLE IF EXISTS roomDistrib")
+        jdbcTemplate.execute("DROP TABLE IF EXISTS tasks")
+        jdbcTemplate.execute("DROP TABLE IF EXISTS taskDependencies")
+        jdbcTemplate.execute("DROP TABLE IF EXISTS treatments")
+    }
+
     fun insertPatient(dbPath: String, patientId: String, gender: String) {
         if (getPatientById(dbPath, patientId) != null) {
             return


### PR DESCRIPTION
This pull request introduces a new method for deleting local databases after simulation and updates the `SimulationController` to utilize this method. The most important changes include the addition of the `deleteDatabase` method in `DatabaseService` and the modification of the `simulate` method in `SimulationController` to call this new method.

Key changes:

* Added the `deleteDatabase` method to drop tables from the specified database.
* Modified the `simulate` method to call `deleteDatabase` for `roomDbUrl`, `scenarioDbUrl`, and `treatmentDbUrl` after simulation.